### PR TITLE
Fixing missing headers

### DIFF
--- a/visual_lib/src/preprocess/pyramid_cpu.cpp
+++ b/visual_lib/src/preprocess/pyramid_cpu.cpp
@@ -22,8 +22,7 @@
 #include <assert.h>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
-#include "visual_lib/preprocess/pyramid.h"
-#include "visual_lib/simd_common.h"
+#include "vilib/preprocess/pyramid.h"
 //CPU Architecture specific includes
 #if defined(__SSE2__)
 #include <emmintrin.h>

--- a/visual_lib/test/src/tests.cpp
+++ b/visual_lib/test/src/tests.cpp
@@ -89,7 +89,7 @@ int main(int argc, char * argv[]) {
   tests.emplace_back(new TestSubframePool());
   tests.emplace_back(new TestPyramidPool());
   // Feature detection
-  tests.emplace_back(new TestFAST(TEST_IMAGE_LIST_EUROC_752_480));
+  tests.emplace_back(new TestFAST(TEST_IMAGE_LIST_EUROC_752_480,100));
   // High level
   tests.emplace_back(new TestFeatureTracker(TEST_IMAGE_LIST_EUROC_752_480,100));
 


### PR DESCRIPTION
The development repository headers were still installed on all the machines I tested, hence the fiasco.
Tested on both the Jetson and my computer.